### PR TITLE
fix: Date Parsing exception during casting

### DIFF
--- a/Lib/Neon.Common/Data/Converters/DateTimeJsonConverter.cs
+++ b/Lib/Neon.Common/Data/Converters/DateTimeJsonConverter.cs
@@ -51,7 +51,7 @@ namespace Neon.Data
         /// <inheritdoc/>
         public override DateTime ReadJson(JsonReader reader, Type objectType, DateTime existingValue, bool hasExistingValue, JsonSerializer serializer)
         {
-            return (DateTime)reader.Value;
+            return DateTime.Parse((string)reader.Value);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
I was getting an exception during the casting from string to DateTime.

This PR uses DateTime parse to convert the string to DateTime.

fixes nforgeio/temporal-samples#3 