### PR TITLE
fix: Getting Null Exception when the client is being disposed

### DIFF
--- a/Lib/Neon.Temporal/Worker.Activity.cs
+++ b/Lib/Neon.Temporal/Worker.Activity.cs
@@ -386,7 +386,14 @@ namespace Neon.Temporal
                     throw new InvalidOperationException($"Unexpected message type [{request.Type}].");
             }
 
-            await Client.ProxyReplyAsync(request, reply);
+            if (Client != null)
+            {
+                await Client.ProxyReplyAsync(request, reply);
+            }
+            else
+            {
+                log.LogError($"Client is null during {reply.Type} workerid: {reply.WorkerId}");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
After the client is disposed there was a thread that was still running and received an activity `InternalMessageTypes.ActivityStoppingRequest` from the temporal-proxy and because the client was null an Exception was throwed.

During the Client disposal if finishes the temporal-proxy process that send the StoppingRequest activity.

This PR fixes #1528